### PR TITLE
fix(client/main): setupLoot being called for player lockpicking house

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -191,6 +191,10 @@ local function setupHouses()
             distance = config.debugPoints and 50 or 1.6,
             interior = sharedConfig.houses[i].interior
         })
+        function point:onEnter()
+            house = self.id
+        end
+        
         function point:onExit()
             lib.hideTextUI()
         end


### PR DESCRIPTION
## Description
setupLoot wasn't creating the points for person who lockpicked into the house, you would have to exit and reenter for loot to be setup.
<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
